### PR TITLE
add support for apple silicon mps

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,19 +54,32 @@ def run(args, verbose=False):
         print(get_param_stamp_from_args(args=args))
         exit()
 
-    # Use cuda?
-    cuda = torch.cuda.is_available() and args.cuda
-    device = torch.device("cuda" if cuda else "cpu")
+    # Use cuda or mps (apple silicon)?
+    cuda = torch.cuda.is_available() and args.gpu
+    mps = torch.backends.mps.is_available() and args.gpu
+    if cuda:
+        device = torch.device("cuda")
+    elif mps:
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
 
-    # Report whether cuda is used
+    # Report whether cuda or mps is used
     if verbose:
-        print("CUDA is {}used".format("" if cuda else "NOT(!!) "))
+        if cuda:
+            print("CUDA is used")
+        elif mps:
+            print("MPS is used (apple silicon GPU)")
+        else:
+            print("NO GPU is used!")
 
     # Set random seeds
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
     if cuda:
         torch.cuda.manual_seed(args.seed)
+    elif mps:
+        torch.mps.manual_seed(args.seed)
 
     #-------------------------------------------------------------------------------------------------#
 

--- a/params/options.py
+++ b/params/options.py
@@ -21,7 +21,7 @@ def add_general_options(parser, main=False, comparison=False, compare_hyper=Fals
     parser.add_argument('--seed', type=int, default=0, help='[first] random seed (for each random-module used)')
     if comparison and (not compare_hyper):
         parser.add_argument('--n-seeds', type=int, default=1, help='how often to repeat?')
-    parser.add_argument('--no-gpus', action='store_false', dest='cuda', help="don't use GPUs")
+    parser.add_argument('--no-gpus', action='store_false', dest='gpu', help="don't use GPUs")
     parser.add_argument('--no-save', action='store_false', dest='save', help="don't save trained models")
     parser.add_argument('--full-stag', type=str, metavar='STAG', default='none', help="tag for saving full model")
     parser.add_argument('--full-ltag', type=str, metavar='LTAG', default='none', help="tag for loading full model")


### PR DESCRIPTION
I just tried out this project and it looks like a great starting point for working on continual learning. Since I'm working on a MacBook with an M4, I wanted to use the integrated GPU with MPS. PyTorch began implementing mps with version 1.12.0. I just installed the current versions (`pytorch 2.6.0` and `torchvision 0.21.0`) and everything seems to be working fine (tested with Demo 1 from the README). If you're interested in this, I can also add the changes I made to `main.py` to the other relevant scripts (`main_pretrain.py`, `main_task_free.py`, and `compare_FI.py` I think).

Performance-wise, the splitMNIST example actually runs slower on the GPU (around 124it/s vs 240it/s on CPU), but on CIFAR10, GPU is much faster (10it/s vs 4it/s).

Let me know what you think!